### PR TITLE
Fix: Use scaled text height in order to also scale offsets correctly

### DIFF
--- a/plymouth/mc.script
+++ b/plymouth/mc.script
@@ -50,7 +50,7 @@ fun text_height(text) {
 }
 
 fun text_height_adj() {
-	return text_height(global.textblank) / Window.GetHeight() / global.scale;
+	return text_height(global.textblank) / Window.GetHeight();
 }
 
 # lets avoid autoscaling because it breaks things :)


### PR DESCRIPTION
Hello there !

Had some time to spare for some debugging tonight, so I decided to investigate why my plymouth screen when using this theme looked like that:
![2025-04-30-23-45-20-028](https://github.com/user-attachments/assets/3434682b-ea86-4c70-9966-ed7390cfe8df)
(meaning the middle boot messages were jammed between the bar and the booting os message, even though none are shown here)

Turns out that there was a small mistake in the plymouth script making it so the offsets of those elements to the screen center was calculated with the height of the unscaled text in mind, hence the squished look.

This pr basically changes that and allows people with scales > 1 (in my case it was 4) to have the exact same look as in the screenshots shown on this repo!