### PR TITLE
Nix Flake: Point paths to the Nix Store and change `convert` to `magick` in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
             # Create smaller versions of assets
             for j in "padlock" "bar"; do
               for i in $(seq 1 6); do
-                convert ./plymouth/$j.png -interpolate Nearest -filter point -resize "$i"00% $PLYMOUTH_THEME_BASEDIR/$j-"$i".png
+                magick ./plymouth/$j.png -interpolate Nearest -filter point -resize "$i"00% $PLYMOUTH_THEME_BASEDIR/$j-"$i".png
               done
             done
 

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,10 @@
             bash
           ];
 
+          # Slightly modified compared to ./install.sh
           installPhase = ''
+            # Change outpaths from /usr to the path in the nix store
+            sed -i "s@\/usr\/@$out\/@" ./plymouth/mc.plymouth
             PLYMOUTH_THEME_BASEDIR=$out/share/plymouth/themes/mc
             FONTCONFIG_PATH=$out/fonts/conf.d/
 


### PR DESCRIPTION
Hello there!

I modified the Nix Flake installation process to point paths in `mc.plymouth` to the proper Nix Store $out path (non-FHS-compliancy yay!). The theme is now working  on my NixOS system ^^

I also  changed the `convert` command to `magick` in the flake, like commit 70eb41b does in `install.sh`.