### PR TITLE
Compatibility with Fedora 42

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ But it also can be used alone, I am not here to judge.
 
 If you use a OS which follows the POSIX filesystem structure (``/etc``, ``/usr`` and friends), the installation is as simple as:
 
-First, install ``git``, ``plymouth`` and ``imagemagick``.
+First, install ``git``, ``plymouth`` and ``imagemagick``. On Fedora, also install ``plymouth-plugin-script``.
 
 And do the following:
 

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 PLYMOUTH_THEME_BASEDIR=${PLYMOUTH_THEME_BASEDIR:=/usr/share/plymouth/themes/mc}
-FONTCONFIG_PATH=${FONTCONFIG_PATH:=/etc/fonts/conf.d/}
+FONTS_BASEDIR=${FONTS_BASEDIR:=/usr/share/fonts}
+FONT_PATH=${FONT_PATH:=/etc/fonts}
+FONTCONFIG_PATH=${FONTCONFIG_PATH:=${FONT_PATH}/conf.d}
 
 # Check for ImageMagick
 which magick >/dev/null 2>&1
@@ -34,6 +36,25 @@ for i in $(seq 1 12); do
 done
 
 # Install dracut config
+PLYMOUTHLIBS_PATH=${PLYMOUTHLIBS_PATH:=/usr/lib/plymouth/}
+
+if [ ! -d ${PLYMOUTHLIBS_PATH} ]; then
+    PLYMOUTHLIBS_PATH=/usr/lib64/plymouth
+fi
+
+if [ ! -d ${PLYMOUTHLIBS_PATH} ]; then
+    echo "Please install Plymouth (On Fedora, plymouth-plugin-script)" && \
+    exit 1
+fi
+
+PLYMOUTHLABELLIB=${PLYMOUTHLABELLIB:=label.so}
+
+if [ ! -e ${PLYMOUTHLIBS_PATH}/${PLYMOUTHLABELLIB} ]; then
+    PLYMOUTHLABELLIB=label-pango.so
+fi
+
+echo -e "install_items+=\" ${PLYMOUTHLIBS_PATH}/script.so ${PLYMOUTHLIBS_PATH}/${PLYMOUTHLABELLIB} ${PLYMOUTHLIBS_PATH}/text.so ${FONTS_BASEDIR}/OTF/Minecraft.otf ${FONT_PATH}/fonts.conf ${FONTCONFIG_PATH}/00-minecraft.conf \"\n" > ./dracut/99-minecraft-plymouth.conf
+
 install -v -d -m 0755 /etc/dracut.conf.d
 install -v -m 0644 ./dracut/* /etc/dracut.conf.d/99-minecraft-plymouth.conf
 


### PR DESCRIPTION
`install.sh` now checks for Plymouth libraries in either `/usr/lib` or `/usr/lib64`, and checks for both `label.so` and `label-pango.so` (`label-pango.so` fixes the font not loading early enough, compared to `label-freetype.so`). Added a note in `README.md` that Fedora (at least my version 42) requires the `plymouth-plugin-script` package.