### PR TITLE
fix(nixos): nest `fonts.packages` under `config`

### DIFF
--- a/nixos.nix
+++ b/nixos.nix
@@ -33,5 +33,5 @@ in
   # Required so that the Minecraft font also appears during shutdown.
   # The issue is that Plymouth NixOS module only includes the font
   # inside of the initram and not on the rootfs.
-  fonts.packages = lib.mkIf cfg.enable [ cfg.package ];
+  config.fonts.packages = lib.mkIf cfg.enable [ cfg.package ];
 }


### PR DESCRIPTION
To prevent such an error:

```
error:
       … while checking flake output 'nixosConfigurations'

       … while checking the NixOS configuration 'nixosConfigurations.feather'

       … while calling the 'seq' builtin
         at /nix/store/rszjv6p6ljig777g7zaf1ii3wcb0q0w4-source/lib/modules.nix:361:18:
          360|         options = checked options;
          361|         config = checked (removeAttrs config [ "_module" ]);
             |                  ^
          362|         _module = checked (config._module);

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: Module `/nix/store/vihq5dbxgyp56j9ydnk1gs013kzmgf5b-source/nixos.nix' has an unsupported attribute `fonts'. This is caused by introducing a top-level `config' or `options' attribute. Add configuration attributes immediately on the top level instead, or move all of them (namely: fonts) into the explicit `config' attribute.
```